### PR TITLE
Change getUsers endpoint to allow "Normal User" 

### DIFF
--- a/src/main/java/com/junichi11/netbeans/modules/backlog/BacklogData.java
+++ b/src/main/java/com/junichi11/netbeans/modules/backlog/BacklogData.java
@@ -163,9 +163,12 @@ public final class BacklogData {
      * @return Users
      */
     public List<User> getUsers() {
-        return getUsers(false);
+        return getUsers(false,repository.getProjectKey());
     }
 
+
+    
+    
     /**
      * Get user icon. Icon size is 16x16.
      *
@@ -208,13 +211,18 @@ public final class BacklogData {
      * you want to use cache data
      * @return Users
      */
-    public List<User> getUsers(boolean isForce) {
+    public List<User> getUsers(boolean isForce, String projectKey ) {
         BacklogClient backlogClient = repository.createBacklogClient();
         if (backlogClient == null) {
             return Collections.emptyList();
         }
         if (users == null || isForce) {
-            users = backlogClient.getUsers();
+            if(projectKey !=null ){
+                
+                users = backlogClient.getProjectUsers(projectKey);
+            }else{
+                users = backlogClient.getUsers();
+            }
         }
         return users;
     }

--- a/src/main/java/com/junichi11/netbeans/modules/backlog/BacklogData.java
+++ b/src/main/java/com/junichi11/netbeans/modules/backlog/BacklogData.java
@@ -218,7 +218,6 @@ public final class BacklogData {
         }
         if (users == null || isForce) {
             if(projectKey !=null ){
-                
                 users = backlogClient.getProjectUsers(projectKey);
             }else{
                 users = backlogClient.getUsers();

--- a/src/main/java/com/junichi11/netbeans/modules/backlog/issue/ui/BacklogIssuePanel.java
+++ b/src/main/java/com/junichi11/netbeans/modules/backlog/issue/ui/BacklogIssuePanel.java
@@ -648,11 +648,16 @@ public class BacklogIssuePanel extends javax.swing.JPanel implements PropertyCha
     }
 
     private void setUsers(BacklogData data) {
-        List<User> users = data.getUsers();
-        assigneeComboBoxModel.removeAllElements();
-        assigneeComboBoxModel.addElement(new UserJSONImpl());
-        for (User user : users) {
-            assigneeComboBoxModel.addElement(user);
+        try{
+            List<User> users = data.getUsers();
+            assigneeComboBoxModel.removeAllElements();
+            assigneeComboBoxModel.addElement(new UserJSONImpl());
+            for (User user : users) {
+                assigneeComboBoxModel.addElement(user);
+            }
+        }catch(Exception e){
+            System.out.print(e);
+            assigneeComboBox.setEnabled(false);
         }
         assigneeComboBox.setModel(assigneeComboBoxModel);
     }


### PR DESCRIPTION
getUsers method of the BacklogData class is receiving an exception from Backlog4j when opening IssuePanel, because is using "global" backlogClient.getUsers() method. I'm a normal user API Key, and seems that user list api endpoint is only for administrators and project administrators. 
Browsing the API, i see another method /api/v2/projects/:projectIdOrKey/users and Backlog4j client has the method.

This changes makes the plugin functional for my "Normal User" API Key.