### PR TITLE
Avoid deadlock between RequestProcessor and FileChooserBuilder

### DIFF
--- a/src/main/java/com/junichi11/netbeans/modules/backlog/issue/ui/BacklogIssuePanel.java
+++ b/src/main/java/com/junichi11/netbeans/modules/backlog/issue/ui/BacklogIssuePanel.java
@@ -1445,22 +1445,15 @@ public class BacklogIssuePanel extends javax.swing.JPanel implements PropertyCha
         "BacklogIssuePanel.message.uploading.attachments=Uploading files"
     })
     private void selectFiles() {
-        // attachment
-        RP.post(new Runnable() {
 
+        class AttachmentUploader implements Runnable {
+            
+            File[] attachments;
+            
             @Override
             public void run() {
+     
                 submitHeaderButton.setEnabled(false);
-                // TODO add FileFilter
-                File[] attachments = new FileChooserBuilder(BacklogIssuePanel.class.getName() + BACKLOG_ATTACHMENT_SUFFIX)
-                        .setTitle(Bundle.BacklogIssuePanel_label_select_file())
-                        .setFilesOnly(true)
-                        .showMultiOpenDialog();
-                if (attachments == null) {
-                    submitHeaderButton.setEnabled(true);
-                    fireChange();
-                    return;
-                }
 
                 // show progress bar
                 ProgressHandle handle = ProgressHandleFactory.createHandle(
@@ -1497,7 +1490,19 @@ public class BacklogIssuePanel extends javax.swing.JPanel implements PropertyCha
                     fireChange();
                 }
             }
-        });
+        }
+                
+        AttachmentUploader attachUploadIntent = new AttachmentUploader();
+        
+        attachUploadIntent.attachments = new FileChooserBuilder(BacklogIssuePanel.class.getName() + BACKLOG_ATTACHMENT_SUFFIX)
+                        .setTitle(Bundle.BacklogIssuePanel_label_select_file())
+                        .setFilesOnly(true)
+                        .showMultiOpenDialog();
+        
+        if(attachUploadIntent.attachments!=null){
+            RP.post(attachUploadIntent);
+        }
+
     }
 
     private void refresh() {

--- a/src/main/java/com/junichi11/netbeans/modules/backlog/issue/ui/BacklogIssuePanel.java
+++ b/src/main/java/com/junichi11/netbeans/modules/backlog/issue/ui/BacklogIssuePanel.java
@@ -1416,7 +1416,12 @@ public class BacklogIssuePanel extends javax.swing.JPanel implements PropertyCha
     }//GEN-LAST:event_refreshLinkButtonActionPerformed
 
     private void selectFilesButtonActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_selectFilesButtonActionPerformed
-        selectFiles();
+        SwingUtilities.invokeLater(new Runnable() {
+           @Override
+           public void run() {
+               selectFiles();
+           }
+        });
     }//GEN-LAST:event_selectFilesButtonActionPerformed
 
     private void addSubtaskLinkButtonActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_addSubtaskLinkButtonActionPerformed

--- a/src/main/java/com/junichi11/netbeans/modules/backlog/issue/ui/BacklogIssuePanel.java
+++ b/src/main/java/com/junichi11/netbeans/modules/backlog/issue/ui/BacklogIssuePanel.java
@@ -1450,11 +1450,20 @@ public class BacklogIssuePanel extends javax.swing.JPanel implements PropertyCha
         "BacklogIssuePanel.message.uploading.attachments=Uploading files"
     })
     private void selectFiles() {
+        // attachment
 
-        class AttachmentUploader implements Runnable {
-            
-            File[] attachments;
-            
+         // TODO add FileFilter
+        final File[] attachments = new FileChooserBuilder(BacklogIssuePanel.class.getName() + BACKLOG_ATTACHMENT_SUFFIX)
+                        .setTitle(Bundle.BacklogIssuePanel_label_select_file())
+                        .setFilesOnly(true)
+                        .showMultiOpenDialog();
+
+        if(attachments==null){
+            return;
+        }
+        
+        RP.post(new Runnable() {
+
             @Override
             public void run() {
      
@@ -1495,19 +1504,7 @@ public class BacklogIssuePanel extends javax.swing.JPanel implements PropertyCha
                     fireChange();
                 }
             }
-        }
-                
-        AttachmentUploader attachUploadIntent = new AttachmentUploader();
-        
-        attachUploadIntent.attachments = new FileChooserBuilder(BacklogIssuePanel.class.getName() + BACKLOG_ATTACHMENT_SUFFIX)
-                        .setTitle(Bundle.BacklogIssuePanel_label_select_file())
-                        .setFilesOnly(true)
-                        .showMultiOpenDialog();
-        
-        if(attachUploadIntent.attachments!=null){
-            RP.post(attachUploadIntent);
-        }
-
+        });
     }
 
     private void refresh() {


### PR DESCRIPTION
Trying to solve issue #32.
Extracted FileChooserBuilder.showMultiDialog() from the logic passed to the RequestProcessor, and wrapped selectFiles() call with SwingUtilities.invokeLaker() to not fire showMultiDialog() in EDT.